### PR TITLE
fix(macos): TUN startup failure (bad tun name) and IPv6 502s in TUN mode

### DIFF
--- a/pkg/singtun/manager.go
+++ b/pkg/singtun/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"runtime"
 	"sync"
 	"time"
 
@@ -115,10 +116,30 @@ func (m *Manager) Start(cfg proxy.TUNConfig, proxyAddr string) error {
 	}
 
 	// 2. 创建 TUN 接口
+	// macOS 仅接受 utunN 形式的接口名（sing-tun darwin 实现以 Sscanf("utun%d")
+	// 解析名称，且不支持序号自动分配），固定名 "SniShaper" 会直接报
+	// "bad tun name"。因此在 darwin 上循环探测空闲序号；其他平台沿用原名。
 	var err error
-	m.tun, err = tun.New(m.options)
-	if err != nil {
-		return fmt.Errorf("create tun failed: %w", err)
+	if runtime.GOOS == "darwin" {
+		var lastErr error
+		for i := 0; i < 128; i++ {
+			m.options.Name = fmt.Sprintf("utun%d", i)
+			t, e := tun.New(m.options)
+			if e == nil {
+				m.tun = t
+				m.logf("[sing-tun] created macOS TUN interface: " + m.options.Name)
+				break
+			}
+			lastErr = e
+		}
+		if m.tun == nil {
+			return fmt.Errorf("create tun failed (tried utun0..utun127): %w", lastErr)
+		}
+	} else {
+		m.tun, err = tun.New(m.options)
+		if err != nil {
+			return fmt.Errorf("create tun failed: %w", err)
+		}
 	}
 
 	// 3. 创建 Handler

--- a/proxy/dialer.go
+++ b/proxy/dialer.go
@@ -389,6 +389,13 @@ func (p *ProxyServer) getPhysicalLocalAddr(targetAddr string) *net.TCPAddr {
 				if ipNet.IP.To4() != nil {
 					continue
 				}
+				// 跳过链路本地地址：绑定 fe80::（无 zone）在 macOS 上会报
+				// "bind: can't assign requested address"（曾导致 TUN 模式下
+				// 所有 IPv6 目标 502）；且链路本地源地址无法路由到全局目标。
+				// 应选用接口上的全局 IPv6 地址（SLAAC/2409:: 等）。
+				if ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.IsLoopback() {
+					continue
+				}
 				return &net.TCPAddr{IP: ipNet.IP}
 			}
 			// IPv4 目标：跳过 IPv6 地址


### PR DESCRIPTION
## Problem 1: hardcoded TUN interface name makes `tun on` always fail on macOS

`pkg/singtun/manager.go` hardcodes the TUN interface name as `SniShaper`, but macOS only accepts `utunN` names. sing-tun v0.8.13's darwin implementation parses the name with `fmt.Sscanf(options.Name, "utun%d", &ifIndex)` and does not support automatic index allocation, so on macOS any user running `tun on` gets:

```
create tun failed: bad tun name: SniShaper
```

**Fix:** on darwin, probe `utun0..utun127` and use the first index that creates successfully; other platforms keep the original name.

Verified on macOS 26.6.1 (arm64):

| Step | Result |
|---|---|
| Before | `create tun failed: bad tun name: SniShaper` |
| After, non-root | `create tun failed (tried utun0..utun127): Connect: operation not permitted` (expected — only missing privileges; name validation passed) |
| After, root | `[sing-tun] created macOS TUN interface: utun11` + `TUN data plane check passed` |

## Problem 2: TUN mode breaks every IPv6 target (502) by binding a link-local source address

The anti-loopback source binding `getPhysicalLocalAddr()` picks the first IPv6 address on the interface for IPv6 targets — on macOS that is the link-local `fe80::` address. Binding to `fe80::` without a zone fails:

```
dial tcp [fe80::…]:0->[2409:8c54:…]:80: bind: can't assign requested address
```

In a 15-minute root-TUN session, 76 of 91 total 502 responses were caused by this single error. sing-tun's UDP path shows the same pattern (`listen udp6 [fe80::…]:0: bind: can't assign requested address`) — likely an upstream issue, out of scope here.

**Fix:** in the `wantIPv6` branch, skip `IsLinkLocalUnicast()` / `IsLoopback()` addresses and bind a global IPv6 address (SLAAC) from the interface instead.

## Build & verification

- `go build -tags "with_gvisor headless" ./cli` — builds cleanly (v1.29.0-beta.1)
- Problem 1 verified end-to-end per the table above
- Problem 2 patch compiles; live IPv6 connectivity retest in progress

## Known issue (out of scope)

Under root-TUN on the macOS CLI I also observed a relay failure where the engine never receives the client's ClientHello for tls-rf domains (`Failed to read initial TLS record ... i/o timeout`). Root cause still under investigation — happy to open a separate issue with full logs if useful.
